### PR TITLE
Use useNativeDriver flag

### DIFF
--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -1,5 +1,6 @@
 import React from "react";
-import { Platform, View, Animated, Modal, TouchableOpacity, Picker, Dimensions, Text } from "react-native";
+import { Platform, View, Animated, Modal, TouchableOpacity, Dimensions, Text } from "react-native";
+import Picker from "@react-native-community/picker";
 import PropTypes from "prop-types";
 
 class ReactNativePickerModule extends React.Component {

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { Platform, View, Animated, Modal, TouchableOpacity, Dimensions, Text } from "react-native";
-import Picker from "@react-native-community/picker";
+import { Picker } from "@react-native-community/picker";
 import PropTypes from "prop-types";
 
 class ReactNativePickerModule extends React.Component {
@@ -42,7 +42,8 @@ class ReactNativePickerModule extends React.Component {
           () => {
             Animated.timing(this.state.animation, {
               toValue: 1,
-              duration: ios.duration
+              duration: ios.duration,
+              useNativeDriver: false
             }).start();
           }
         );
@@ -148,7 +149,8 @@ class ReactNativePickerModule extends React.Component {
                     onDismiss !== undefined && onDismiss();
                     Animated.timing(this.state.animation, {
                       toValue: 0,
-                      duration: ios.duration
+                      duration: ios.duration,
+                      useNativeDriver: false
                     }).start(() => {
                       this.setState({
                         isVisible: false
@@ -178,7 +180,8 @@ class ReactNativePickerModule extends React.Component {
                 onPress={() => {
                   Animated.timing(this.state.animation, {
                     toValue: 0,
-                    duration: ios.duration
+                    duration: ios.duration,
+                    useNativeDriver: false
                   }).start(() => {
                     this.setState({
                       isVisible: false

--- a/package.json
+++ b/package.json
@@ -17,6 +17,9 @@
   ],
   "author": "Talut TASGIRAN",
   "license": "MIT",
+  "dependencies": {
+    "@react-native-community/picker": "^1.3.0"
+  },
   "peerDependencies": {
     "react-native": "^0.60.5",
     "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -17,11 +17,9 @@
   ],
   "author": "Talut TASGIRAN",
   "license": "MIT",
-  "dependencies": {
-    "@react-native-community/picker": "^1.3.0"
-  },
   "peerDependencies": {
-    "react-native": "^0.60.5",
+    "@react-native-community/picker": "^1.3.0",
+    "react-native": "0.62.0",
     "prop-types": "^15.7.2"
   },
   "publishConfig": {"registry": "https://npm.pkg.github.com/@talut"},


### PR DESCRIPTION
Added in the `useNativeDriver` and peer dependency for `@react-native-community/picker` as the react-native picker is being deprecated