### PR TITLE
iOS fixes 

### DIFF
--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -32,7 +32,8 @@ const ReactNativePickerModule = ({
     }
   }
   const [isVisible, setIsVisible] = useState(false)
-  const [selectedValue, setSelectedValue] = useState(
+  const [selectedValue, setSelectedValue] = useState()
+  const setDefaultSelectedValue = () => setSelectedValue(
     !value ? (typeof items[0] === "object" ? items[0].value : items[0]) : value,
   )
   useEffect(() => {
@@ -47,6 +48,7 @@ const ReactNativePickerModule = ({
       backdropOpacity={backdropOpacity}
       onBackdropPress={dismissPress}
       onBackButtonPress={dismissPress}
+      onShow={setDefaultSelectedValue}
       useNativeDriver={useNativeDriver}
       isVisible={isVisible}
       style={{ justifyContent: "flex-end" }}

--- a/lib/index.ios.js
+++ b/lib/index.ios.js
@@ -61,7 +61,7 @@ const ReactNativePickerModule = ({
           itemStyle={itemStyle}
           selectedValue={selectedValue}
           style={{ maxHeight: 200, overflow: "hidden" }}
-          onValueChange={setSelectedValue}>
+          onValueChange={(itemValue,itemIndex) => setSelectedValue(itemValue)}>
           {items.map((item, index) => {
             if (item.hasOwnProperty("value") && item.hasOwnProperty("label")) {
               return (

--- a/react-native-picker-module.d.ts
+++ b/react-native-picker-module.d.ts
@@ -9,7 +9,7 @@ export interface ReactNativePickerModuleProps {
   value?: string
   items: string[]
   title?: string
-  pickerRef: any[]
+  pickerRef: React.RefObject<ReactNativePickerModule>
   onValueChange: (value: string) => void
   onCancel?: () => void
   cancelButton?: string


### PR DESCRIPTION
**This PR contains 3 fixes**
- The issue where the selectedValue doesn't get updated when using the picker multiple times with different arrays.

- The "Warning: State updates from the useState() and useReducer() Hooks don't support the second callback argument." warning.

- No overload matches this call.
  Overload 1 of 2, '(props: Readonly<ReactNativePickerModuleProps>): ReactNativePickerModule', gave the following error.
    Type 'RefObject<ReactNativePickerModule>' is missing the following properties from type 'any[]': length, pop, push, concat, and 26 more.
  Overload 2 of 2, '(props: ReactNativePickerModuleProps, context?: any): ReactNativePickerModule', gave the following error.
    Type 'RefObject<ReactNativePickerModule>' is not assignable to type 'any[]'.