### PR TITLE
fix: reset enabled state when binding `RecyclerView.ViewHolder`

### DIFF
--- a/android/src/main/java/com/taluttasgiran/pickermodule/RNSpinnerAdapter.java
+++ b/android/src/main/java/com/taluttasgiran/pickermodule/RNSpinnerAdapter.java
@@ -119,6 +119,8 @@ public class RNSpinnerAdapter extends RecyclerView.Adapter<RNSpinnerAdapter.MyVi
                 if (selectedColor != null) {
                     button.setTextColor(Color.parseColor(selectedColor));
                 }
+            } else {
+                button.setEnabled(true);
             }
         }
         button.setOnClickListener(v -> {


### PR DESCRIPTION
Since RecyclerView re-use the same views, if the enabled state is not reset, this will made random items appear as selected even if they are not.


https://user-images.githubusercontent.com/8727739/225355544-5de4301a-0d47-474c-aa70-e0c94c0a6173.mp4

